### PR TITLE
Make $scalar->reverse always reverse $scalar, regardless of context

### DIFF
--- a/lib/autobox/Core.pm
+++ b/lib/autobox/Core.pm
@@ -776,7 +776,9 @@ sub lcfirst ($)   { CORE::lcfirst($_[0]); }
 sub length  ($)   { CORE::length($_[0]); }
 sub ord     ($)   { CORE::ord($_[0]); }
 sub pack    ($;@) { CORE::pack(shift, @_); }
-sub reverse ($)   { CORE::reverse($_[0]); }
+sub reverse ($)   {
+    wantarray ? return my $r = CORE::reverse($_[0]) : CORE::reverse($_[0]);
+}
 
 sub rindex  ($@)  {
     return CORE::rindex($_[0], $_[1]) if @_ == 2;

--- a/t/reverse.t
+++ b/t/reverse.t
@@ -4,6 +4,12 @@ use warnings;
 
 use autobox::Core;
 
+# https://github.com/schwern/perl5i/issues/182
+my $scalar = 'foo';
+my($reverse) = $scalar->reverse;  # list context
+is $reverse, 'oof', 'reverse in list context reverses the scalar';
+is scalar $scalar->reverse, 'oof', 'reverse in scalar context reverses the scalar';
+
 is "Hello"->reverse, "olleH";
 
 my @list = qw(foo bar baz);


### PR DESCRIPTION
In list context, this previously reversed the list ($scalar), thus
doing nothing. Now, this will actually reverse the contents of
the scalar.

Fixes schwern/perl5i#182
