### PR TITLE
Fix hash ordering bug in flip test

### DIFF
--- a/t/flip.t
+++ b/t/flip.t
@@ -2,7 +2,7 @@
 use Test::More tests => 2;
 use autobox::Core;
 
-my %hash = ( 1 => 'foo', 2 => 'bar', 3 => 'bar' );
+my %hash = ( 1 => 'foo', 3 => 'bar' );
 my $f;
 
 is_deeply( $f = %hash->flip, { foo => 1, bar => 3 } );


### PR DESCRIPTION
The test was relying on the clashing values coming out in a particular order, which only happened to work before, and is definitely not the case on perl 5.18.
