### PR TITLE
add ::UNDEF and undef->length()

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for autobox::Core
 
+1.28
+   New Features
+   - add undef->length() method to be consistent with the other types (Chris
+     Weyl @RsrchBoy)
+
 1.27
    Misc
    - new version just to creage a new .tar.gz.  a './' owned by root

--- a/lib/autobox/Core.pm
+++ b/lib/autobox/Core.pm
@@ -55,7 +55,11 @@ use B;
 #    use autobox::Core UNIVERSAL => 'Data::Dumper';     # enable a Dumper() method for all types
 
 sub import {
-    shift->SUPER::import(DEFAULT => 'autobox::Core::', @_);
+    shift->SUPER::import(
+        DEFAULT => 'autobox::Core::',
+        UNDEF   => 'autobox::Core::UNDEF',
+        @_,
+    );
 }
 
 =encoding UTF-8
@@ -1904,6 +1908,16 @@ sub ref      { CORE::ref   $_[0] }
 # perl 6-isms
 
 sub curry  { my $code = CORE::shift; my @args = @_; sub { CORE::unshift @_, @args; goto &$code; }; }
+
+##############################################################################################
+
+#
+# UNDEF
+#
+
+package autobox::Core::UNDEF;
+
+sub length { undef }
 
 1;
 

--- a/lib/autobox/Core.pm
+++ b/lib/autobox/Core.pm
@@ -887,6 +887,18 @@ the first argument filled in.
     my $howdy_world = $greet_world->curry("Howdy");
     print $howdy_world->("Texas");           # "Howdy, Texas!"
 
+=head3 undef Methods
+
+Methods that work on "undefined" values.
+
+=head4 length
+
+    # $warnings may be an empty arrayref, a populated arrayref, or undef
+    if ($warnings->length) { ... }
+
+C<undef->length()> will always return C<undef>.  This allows one to use it
+without fear in a scenario such as in the example, and makes it consistent
+with the behavior of the other C<length()> methods we provide.
 
 =head2 What's Missing?
 

--- a/t/length.t
+++ b/t/length.t
@@ -12,3 +12,8 @@ my @array = qw(foo bar baz);
 
 is @array->length, 3;
 
+my $arrayref;
+
+is $arrayref->length => undef, 'undef->length() returns undef';
+$arrayref = [];
+is $arrayref->length => 0,     '[]->length() returns 0';


### PR DESCRIPTION
This is a convienience method, designed to make life easier when dealing
with that may or may not be undefined; namely lists.

e.g.

```
# ... $warnings *may* be an empty/populated arrayref or undefined
my $warnings;

# ...

# old-school:
if (!!$warnings && @$warnings) { ... }

 # new-school: (if I may be so bold)
if ($warnings->length) { ... }
```

Enabling ->length() to work for any of these contexts stops my eyes from
crossing^W^W^W^W^Wsimplifies the logic required in this common scenario.
