### PR TITLE
Handle systems without crypt()

### DIFF
--- a/t/crypt.t
+++ b/t/crypt.t
@@ -3,4 +3,8 @@ use strict;
 use warnings;
 use autobox::Core;
 
-is 'PLAINTEXT'->crypt('SALT'), 'SAPH9ylAEPe62';
+use Config;
+SKIP: {
+    skip("crypt not defined on this system", 1) unless $Config{d_crypt};
+    is 'PLAINTEXT'->crypt('SALT'), 'SAPH9ylAEPe62';
+}


### PR DESCRIPTION
This is really just to get the module installing cleanly on Android, but technically affects any perl built with -Ud_crypt
