### PR TITLE
suppress experimental smartmatch warnings on newer perls

### DIFF
--- a/lib/autobox/Core.pm
+++ b/lib/autobox/Core.pm
@@ -1568,6 +1568,8 @@ sub flip {
 ##############################################################################################
 package autobox::Core::ARRAY;
 
+no if $] >= 5.018, warnings => 'experimental::smartmatch';
+
 use constant FIVETEN => ($] >= 5.010);
 
 use Carp 'croak';


### PR DESCRIPTION
Since Perl 5.18, there is a warning which informs us that smartmatch is an experimental feature. This can be annoying, so I have disabled it.