### PR TITLE
Make m() and nm() should return false when needed

### DIFF
--- a/lib/autobox/Core.pm
+++ b/lib/autobox/Core.pm
@@ -1298,8 +1298,8 @@ sub quotemeta  { CORE::quotemeta($_[0]); }
 sub vec        { CORE::vec($_[0], $_[1], $_[2]); }
 sub undef      { $_[0] = undef }
 sub defined    { CORE::defined($_[0]) }
-sub m          { [ $_[0] =~ m{$_[1]} ] }
-sub nm         { [ $_[0] !~ m{$_[1]} ] }
+sub m          { my @ms = $_[0] =~ m{$_[1]} ;  return @ms ? \@ms : undef }
+sub nm         { my @ms = $_[0] =~ m{$_[1]} ;  return @ms ? undef : \@ms }
 sub s          { $_[0] =~ s{$_[1]}{$_[2]} }
 sub split      { wantarray ? split $_[1], $_[0] : [ split $_[1], $_[0] ] }
 

--- a/t/m.t
+++ b/t/m.t
@@ -4,3 +4,4 @@ use warnings;
 use autobox::Core;
 
 ok 'foo'->m(qr/o+/);
+ok ! 'foo'->m(qr/x+/);

--- a/t/nm.t
+++ b/t/nm.t
@@ -4,3 +4,4 @@ use warnings;
 use autobox::Core;
 
 ok 'bar'->nm(qr/o+/);
+ok ! 'bar'->nm(qr/bar/);


### PR DESCRIPTION
This should print "no match":
 
     perl -MABC  -E 'if ("foo"->m(qr/xxx/) ) { say "matches"} else { say "no match"} '

but fails since `->m()` does not return false when there is no match. Defining `m()` so that it returns false fixes this. *e.g.*: `sub autobox::Core::SCALAR::m { my @ms = $_[0] =~ m{$_[1]} ;  return @ms ? \@ms : undef } `

This pull requests changes `->m()` and `->nm()` in `package autobox::Core::SCALAR` to return false
and add tests to `t/m.t` and `t/nm.t1`. 

Fixes:  https://github.com/scrottie/autobox-Core/issues/29